### PR TITLE
Fix type of fileContent

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,7 +16,7 @@ declare namespace Cypress {
     | string
     | {
         filePath?: string;
-        fileContent?: Blob;
+        fileContent?: Blob | object;
         fileName?: string;
         encoding?: FixtureEncoding;
         mimeType?: string;


### PR DESCRIPTION
#### Checklist:

- [x] No linting issues
- [x] Commits are compliant with commitizen
- [x] CI tests have passed
- [ ] Documentation updated

#### Summary of changes
When file extension is json, file content needs to be an object and not Blob.  
You can see it there:   
https://github.com/abramenal/cypress-file-upload/blob/45ae45cc97c4833e594285c9631208246e27413c/lib/file/getFileBlobAsync.js#L27

So I changed the contentFile type to be a Blob or object

